### PR TITLE
Fixed issue where large text on small space is truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the project will be documented in this file.
 #### Bugfixes
 
 - Fixed `fontSizeThatFits` when used with empty strings
+- Improved issue with long strings in small labels getting truncated
 
 ## [1.2.0](https://github.com/tbaranes/FittableFontLabel/releases/tag/1.2.0) (01/08/2016)
  

--- a/FittableFontLabel/FittableFontLabel iOS Tests/FittableFontLabelTests.swift
+++ b/FittableFontLabel/FittableFontLabel iOS Tests/FittableFontLabelTests.swift
@@ -24,8 +24,6 @@ class FittableFontLabelTests: XCTestCase {
     let shortText = "Etiam turpis elit"
     // swiftlint:disable:next line_length
     let longText = "Etiam turpis elit, efficitur nec suscipit vitae, aliquam vitae lorem. Aenean mauris tortor, semper vel facilisis nec, facilisis ut neque. Aliquam erat volutpat. Nam eget varius mauris, ut condimentum quam. Duis ex nisi, iaculis in ex ut, lobortis pretium est. Sed non lorem venenatis, fermentum quam aliquet, ultrices arcu. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis ullamcorper convallis tellus, vitae bibendum mi dapibus in. Morbi pellentesque aliquet urna, id aliquet orci efficitur sed. Donec et mi urna. Proin sagittis semper massa in semper."
-
-  let optimalFontSize: CGFloat = 2.0703125
 }
 
 // MARK: - Single line
@@ -39,7 +37,7 @@ extension FittableFontLabelTests {
         label.text = longText
         let fontSize = label.fontSizeThatFits(text: longText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 20, height: 20))
-        XCTAssertEqual(fontSize, optimalFontSize)
+        XCTAssertEqual(fontSize, 2.0)
     }
 
     func testSingleLine_expectingMaxSize() {
@@ -72,7 +70,7 @@ extension FittableFontLabelTests {
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         let fontSize = label.fontSizeThatFits(text: shortText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 0, height: 0))
-        XCTAssertEqual(fontSize, optimalFontSize)
+        XCTAssertEqual(fontSize, 2.0)
     }
 
 }
@@ -89,7 +87,7 @@ extension FittableFontLabelTests {
         label.text = longText
         let fontSize = label.fontSizeThatFits(text: longText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 0, height: 0))
-        XCTAssertEqual(fontSize, optimalFontSize)
+        XCTAssertEqual(fontSize, 2.0)
     }
 
     func testMultiline_expectingMaxSize() {
@@ -126,7 +124,7 @@ extension FittableFontLabelTests {
         label.numberOfLines = 0
         let fontSize = label.fontSizeThatFits(text: shortText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 0, height: 0))
-        XCTAssertEqual(fontSize, optimalFontSize)
+        XCTAssertEqual(fontSize, 2.0)
     }
 
 }

--- a/FittableFontLabel/FittableFontLabel iOS Tests/FittableFontLabelTests.swift
+++ b/FittableFontLabel/FittableFontLabel iOS Tests/FittableFontLabelTests.swift
@@ -24,6 +24,8 @@ class FittableFontLabelTests: XCTestCase {
     let shortText = "Etiam turpis elit"
     // swiftlint:disable:next line_length
     let longText = "Etiam turpis elit, efficitur nec suscipit vitae, aliquam vitae lorem. Aenean mauris tortor, semper vel facilisis nec, facilisis ut neque. Aliquam erat volutpat. Nam eget varius mauris, ut condimentum quam. Duis ex nisi, iaculis in ex ut, lobortis pretium est. Sed non lorem venenatis, fermentum quam aliquet, ultrices arcu. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis ullamcorper convallis tellus, vitae bibendum mi dapibus in. Morbi pellentesque aliquet urna, id aliquet orci efficitur sed. Donec et mi urna. Proin sagittis semper massa in semper."
+
+  let optimalFontSize: CGFloat = 2.0703125
 }
 
 // MARK: - Single line
@@ -37,7 +39,7 @@ extension FittableFontLabelTests {
         label.text = longText
         let fontSize = label.fontSizeThatFits(text: longText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 20, height: 20))
-        XCTAssertEqual(fontSize, 20 * 0.1)
+        XCTAssertEqual(fontSize, optimalFontSize)
     }
 
     func testSingleLine_expectingMaxSize() {
@@ -70,7 +72,7 @@ extension FittableFontLabelTests {
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         let fontSize = label.fontSizeThatFits(text: shortText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 0, height: 0))
-        XCTAssertEqual(fontSize, 20 * 0.1)
+        XCTAssertEqual(fontSize, optimalFontSize)
     }
 
 }
@@ -87,7 +89,7 @@ extension FittableFontLabelTests {
         label.text = longText
         let fontSize = label.fontSizeThatFits(text: longText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 0, height: 0))
-        XCTAssertEqual(fontSize, 20 * 0.1)
+        XCTAssertEqual(fontSize, optimalFontSize)
     }
 
     func testMultiline_expectingMaxSize() {
@@ -124,7 +126,7 @@ extension FittableFontLabelTests {
         label.numberOfLines = 0
         let fontSize = label.fontSizeThatFits(text: shortText, maxFontSize: 20, minFontScale: 0.1,
                                               rectSize: CGSize(width: 0, height: 0))
-        XCTAssertEqual(fontSize, 20 * 0.1)
+        XCTAssertEqual(fontSize, optimalFontSize)
     }
 
 }

--- a/Sources/UILabelExtension.swift
+++ b/Sources/UILabelExtension.swift
@@ -89,7 +89,8 @@ private extension UILabel {
     }
 
     func binarySearch(string: String, minSize: CGFloat, maxSize: CGFloat, size: CGSize, constraintSize: CGSize) -> CGFloat {
-        guard maxSize > minSize else {
+        let diff = maxSize - minSize
+        guard diff > 0.1 else {
             return maxSize
         }
 
@@ -101,8 +102,8 @@ private extension UILabel {
         let state = numberOfLines == 1 ? singleLineSizeState(rect: rect, size: size) : multiLineSizeState(rect: rect, size: size)
         switch state {
         case .Fit: return fontSize
-        case .TooBig: return binarySearch(string: string, minSize: minSize, maxSize: maxSize - 1, size: size, constraintSize: constraintSize)
-        case .TooSmall: return binarySearch(string: string, minSize: fontSize + 1, maxSize: maxSize, size: size, constraintSize: constraintSize)
+        case .TooBig: return binarySearch(string: string, minSize: minSize, maxSize: fontSize, size: size, constraintSize: constraintSize)
+        case .TooSmall: return binarySearch(string: string, minSize: fontSize, maxSize: maxSize, size: size, constraintSize: constraintSize)
         }
     }
 
@@ -117,8 +118,10 @@ private extension UILabel {
     }
 
     func multiLineSizeState(rect: CGRect, size: CGSize) -> FontSizeState {
-        if rect.height >= size.height + 10 && rect.height <= size.height &&
-            rect.width >= size.width + 10 && rect.width <= size.width {
+        if rect.height < size.height + 10 &&
+           rect.height > size.height - 10 &&
+           rect.width > size.width + 10 &&
+           rect.width < size.width - 10 {
             return .Fit
         } else if rect.height > size.height || rect.width > size.width {
             return .TooBig

--- a/Sources/UILabelExtension.swift
+++ b/Sources/UILabelExtension.swift
@@ -100,12 +100,12 @@ private extension UILabel {
         // returning either side of min or max depending on the state
         let diff = maxSize - minSize
         guard diff > 0.1 else {
-          switch state {
-          case .TooSmall:
-            return maxSize
-          default:
-            return minSize
-          }
+            switch state {
+            case .TooSmall:
+                return maxSize
+            default:
+                return minSize
+            }
         }
 
         switch state {
@@ -126,6 +126,7 @@ private extension UILabel {
     }
 
     func multiLineSizeState(rect: CGRect, size: CGSize) -> FontSizeState {
+        // if rect within 10 of size
         if rect.height < size.height + 10 &&
            rect.height > size.height - 10 &&
            rect.width > size.width + 10 &&

--- a/Sources/UILabelExtension.swift
+++ b/Sources/UILabelExtension.swift
@@ -89,17 +89,25 @@ private extension UILabel {
     }
 
     func binarySearch(string: String, minSize: CGFloat, maxSize: CGFloat, size: CGSize, constraintSize: CGSize) -> CGFloat {
-        let diff = maxSize - minSize
-        guard diff > 0.1 else {
-            return maxSize
-        }
-
         let fontSize = (minSize + maxSize) / 2
         var attributes = currentAttributedStringAttributes()
         attributes[NSFontAttributeName] = font.withSize(fontSize)
 
         let rect = string.boundingRect(with: constraintSize, options: .usesLineFragmentOrigin, attributes: attributes, context: nil)
         let state = numberOfLines == 1 ? singleLineSizeState(rect: rect, size: size) : multiLineSizeState(rect: rect, size: size)
+
+        // if the search range is smaller than 0.1 of a font size we stop
+        // returning either side of min or max depending on the state
+        let diff = maxSize - minSize
+        guard diff > 0.1 else {
+          switch state {
+          case .TooSmall:
+            return maxSize
+          default:
+            return minSize
+          }
+        }
+
         switch state {
         case .Fit: return fontSize
         case .TooBig: return binarySearch(string: string, minSize: minSize, maxSize: fontSize, size: size, constraintSize: constraintSize)


### PR DESCRIPTION
Font size search goes a few steps deeper and .Fit logic makes more sense
Binary search now goes exactly midway between each branch until termination
Tests updated to use specific optimalFontSize variable

I am not sure what you will think of this commit but the previous code was failing for me on some edge cases and this seems to solve them.
