### PR TITLE
Fix issue caused when font size calculated with long decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ N/A
 
 #### Bugfixes
 
-N/A
+- Fix rounding when calculated font size has long decimals therefore rendering results with cutting off the last line (probably due to rounding up in UILabel rendering)
 
 ## [3.0.0](https://github.com/tbaranes/FittableFontLabel/releases/tag/3.0.0) (18-09-2018)
 

--- a/Source/UILabelExtension.swift
+++ b/Source/UILabelExtension.swift
@@ -60,7 +60,8 @@ public extension UILabel {
         let constraintSize = numberOfLines == 1 ?
             CGSize(width: CGFloat.greatestFiniteMagnitude, height: rectSize.height) :
             CGSize(width: rectSize.width, height: CGFloat.greatestFiniteMagnitude)
-        return binarySearch(string: string, minSize: minimumFontSize, maxSize: maxFontSize, size: rectSize, constraintSize: constraintSize)
+        let calculatedFontSize = binarySearch(string: string, minSize: minimumFontSize, maxSize: maxFontSize, size: rectSize, constraintSize: constraintSize)
+        return (calculatedFontSize * 10.0).rounded(.down) / 10.0
     }
 
 }


### PR DESCRIPTION
In my case the calculated value was `20.019...` which actually didn't display properly, it cut off the last line, but when rounded to have 1 decimal (`20.0`) it rendered with the full text.

My "workaround" might not be the most elegant, but does the job.

I'm open for suggestions to improve it.